### PR TITLE
fix: Renovate config for graphql-java releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,11 @@
 {
   "extends": [
     "config:base"
+  ],
+  "packageRules" : [
+    {
+      "matchPackagePrefixes": ["com.graphql-java:"],
+      "allowedVersions": "/^[0-9]+\\.[0-9]+(\\.[0-9]+)?$/"
+    }
   ]
 }


### PR DESCRIPTION
Update renovate config to ignore nightly snapshot publications of `graphql-java`