### PR TITLE
docs: remove build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 # graphql-java-datetime
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/tailrocks/graphql-java-datetime/blob/master/LICENSE) 
-[![Build Status](https://travis-ci.org/tailrocks/graphql-java-datetime.svg?branch=master)](https://travis-ci.org/tailrocks/graphql-java-datetime)
 [![Latest Release](https://img.shields.io/maven-central/v/tailrocks/graphql-java-datetime)](https://maven-badges.herokuapp.com/maven-central/tailrocks/graphql-java-datetime/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/tailrocks/graphql-java-datetime/pulls)
 


### PR DESCRIPTION
Assume this is no longer needed since the move from TravisCI to Github Actions