### PR TITLE
fix: graphql-java-kickstart v12.0.0 does not work with graphql-java 18.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Add the following to your `pom.xml`:
 
 for **GraphQL Java Kickstart**:
 
+*Note: requires graphql-java:17.x until graphql-java-kickstart:graphql-spring-boot:13.x is released*
+
 ```xml
 <dependency>
     <groupId>com.tailrocks.graphql</groupId>

--- a/samples/kickstart-webflux/build.gradle.kts
+++ b/samples/kickstart-webflux/build.gradle.kts
@@ -14,6 +14,9 @@ the<io.spring.gradle.dependencymanagement.dsl.DependencyManagementExtension>().a
 dependencies {
     implementation(project(":graphql-datetime-kickstart-spring-boot-starter"))
 
+    // FIXME - downgrade graphql-java until graphql-java-kickstart release v13 (with graphql-java 18.x support)
+    implementation("com.graphql-java:graphql-java:17.3")
+
     // Spring Boot
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/samples/kickstart-webmvc/build.gradle.kts
+++ b/samples/kickstart-webmvc/build.gradle.kts
@@ -14,6 +14,9 @@ the<io.spring.gradle.dependencymanagement.dsl.DependencyManagementExtension>().a
 dependencies {
     implementation(project(":graphql-datetime-kickstart-spring-boot-starter"))
 
+    // FIXME - downgrade graphql-java until graphql-java-kickstart release v13 (with graphql-java 18.x support)
+    implementation("com.graphql-java:graphql-java:17.3")
+
     // Spring Boot
     implementation("org.springframework.boot:spring-boot-starter-web")
     testImplementation("org.springframework.boot:spring-boot-starter-test")


### PR DESCRIPTION
graphql-java-kickstart:graphql-spring-boot 12.x depends on graphql-java-tools 11.1.0 and graphql-java 17.3.  

when graphql-java 18.x was released, there was a number of major changes.  these are incorporated into graphql-java-tools 12.1.0.

temporarily downgrading the sample projects to graphql-java 17.x until [graphql-java-kickstart:graphql-spring-boot 13.x ](https://github.com/graphql-java-kickstart/graphql-spring-boot/milestone/28)is released, which will update the graphql-java-tools and graphql-java versions